### PR TITLE
[TASK] [ED-553] Adding YotiCalled callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,19 @@ yotiSDKButton.setOnYotiButtonListener(new YotiSDKButton.OnYotiButtonClickListene
     });
 ```
 
+There is also a listener that you can set to be notified when the intent has been sent to the Yoti app.
+When this happens you would probably want to restore your state.
+
+
+```java
+        yotiSDKButton.setOnYotiCalledListener(new YotiSDKButton.OnYotiCalledListener() {
+            @Override
+            public void onYotiCalled() {
+                // Restore the original state
+            }
+        }); 
+```
+[See this code in one of our sample apps](./sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/MainActivity.java)
 
 You can activate a verbose mode for the SDK by using this method :
 ```java

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,6 @@ allprojects {
 
         // Testing
         libJunit = "junit:junit:${libJunitVersion}"
-        libMockito = "org.mockito:mockito-all:${libMockitoVersion}"
+        libMockito = "org.mockito:mockito-core:${libMockitoVersion}"
     }
 }

--- a/sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/MainActivity.java
+++ b/sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/MainActivity.java
@@ -54,6 +54,15 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
+        yotiSDKButton.setOnYotiCalledListener(new YotiSDKButton.OnYotiCalledListener() {
+            @Override
+            public void onYotiCalled() {
+                // Restore the original state
+                yotiSDKButton.setVisibility(View.VISIBLE);
+                progress.setVisibility(View.GONE);
+            }
+        });
+
         if (getIntent().hasExtra(ShareAttributesResultBroadcastReceiver.EXTRA_CANCELLED_BY_USER)) {
             yotiSDKButton.setVisibility(View.VISIBLE);
             progress.setVisibility(View.GONE);

--- a/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/YotiSDK.java
+++ b/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/YotiSDK.java
@@ -3,6 +3,7 @@ package com.yoti.mobile.android.sdk;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.os.ResultReceiver;
 import android.support.annotation.Nullable;
 
 import com.yoti.mobile.android.sdk.exceptions.YotiSDKException;
@@ -92,7 +93,9 @@ public class YotiSDK {
      * @throws YotiSDKException
      */
     /*package*/
-    static void startScenario(final Context context, final String useCaseId, final boolean handleNoYotiAppError) throws YotiSDKException {
+    static void startScenario(final Context context, final String useCaseId,
+                              final boolean handleNoYotiAppError,
+                              final ResultReceiver onYotiCalledResultReceiver) throws YotiSDKException {
 
         YotiSDKLogger.debug("Starting scenario " + useCaseId);
 
@@ -127,7 +130,7 @@ public class YotiSDK {
         }
 
         YotiSDKLogger.debug("Started scenario " + useCaseId);
-        KernelSDKIntentService.startActionStartScenario(context, useCaseId);
+        KernelSDKIntentService.startActionStartScenario(context, useCaseId, onYotiCalledResultReceiver);
     }
 
     /**

--- a/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/YotiSDKButton.java
+++ b/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/YotiSDKButton.java
@@ -87,7 +87,7 @@ public class YotiSDKButton extends YotiButton implements View.OnClickListener {
         mOnYotiAppNotInstalledListener = listener;
     }
 
-    public void setOnYotiCalledListener(@NonNull OnYotiCalledListener listener) {
+    public void setOnYotiCalledListener(@Nullable OnYotiCalledListener listener) {
         mOnYotiCalledListener = listener;
     }
 

--- a/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/YotiSDKButton.java
+++ b/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/YotiSDKButton.java
@@ -2,6 +2,10 @@ package com.yoti.mobile.android.sdk;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.ResultReceiver;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.AppCompatButton;
 import android.util.AttributeSet;
@@ -19,6 +23,17 @@ public class YotiSDKButton extends YotiButton implements View.OnClickListener {
     private String mUseCaseId;
     private OnYotiButtonClickListener mOnYotiButtonClickListener;
     private OnYotiAppNotInstalledListener mOnYotiAppNotInstalledListener;
+    private OnYotiCalledListener mOnYotiCalledListener;
+
+    private ResultReceiver mYotiCallResultReceiver = new ResultReceiver(new Handler()) {
+        @Override
+        protected void onReceiveResult(int resultCode, Bundle resultData) {
+            super.onReceiveResult(resultCode, resultData);
+            if (mOnYotiCalledListener != null) {
+                mOnYotiCalledListener.onYotiCalled();
+            }
+        }
+    };
 
     public YotiSDKButton(Context context) {
         super(context);
@@ -72,6 +87,10 @@ public class YotiSDKButton extends YotiButton implements View.OnClickListener {
         mOnYotiAppNotInstalledListener = listener;
     }
 
+    public void setOnYotiCalledListener(@NonNull OnYotiCalledListener listener) {
+        mOnYotiCalledListener = listener;
+    }
+
     @Override
     public void onClick(View v) {
 
@@ -80,7 +99,7 @@ public class YotiSDKButton extends YotiButton implements View.OnClickListener {
         }
 
         try {
-            YotiSDK.startScenario(getContext(), mUseCaseId, mOnYotiAppNotInstalledListener == null);
+            YotiSDK.startScenario(getContext(), mUseCaseId, mOnYotiAppNotInstalledListener == null, mYotiCallResultReceiver);
         } catch (YotiSDKException cause) {
 
             YotiSDKLogger.error(cause.getMessage(), cause);
@@ -103,5 +122,9 @@ public class YotiSDKButton extends YotiButton implements View.OnClickListener {
 
     public interface OnYotiAppNotInstalledListener {
         void onYotiAppNotInstalledError(YotiSDKNoYotiAppException cause);
+    }
+
+    public interface OnYotiCalledListener {
+        void onYotiCalled();
     }
 }

--- a/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/kernelSDK/KernelSDKIntentService.java
+++ b/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/kernelSDK/KernelSDKIntentService.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.net.Uri;
+import android.os.ResultReceiver;
 import android.text.TextUtils;
 
 import com.yoti.mobile.android.sdk.YotiSDK;
@@ -35,6 +36,7 @@ public class KernelSDKIntentService extends IntentService {
 
     private static final String ACTION_BACKEND_CALL = "com.yoti.mobile.android.sdk.network.action.BACKEND_CALL";
     private static final String ACTION_START_SCENARIO = "com.yoti.mobile.android.sdk.network.action.START_SCENARIO";
+    private static final String YOTI_CALLED_RESULT_RECEIVER = "com.yoti.mobile.android.sdk.network.action.YOTI_CALLED_RESULT_RECEIVER";
 
     private static final String EXTRA_USE_CASE_ID = "com.yoti.mobile.android.sdk.network.extra.USE_CASE_ID";
     private KernelSDK mKernelSDK;
@@ -67,10 +69,11 @@ public class KernelSDKIntentService extends IntentService {
      *
      * @see IntentService
      */
-    public static void startActionStartScenario(Context context, String useCaseId) {
+    public static void startActionStartScenario(Context context, String useCaseId, ResultReceiver resultReceiver) {
         Intent intent = new Intent(context, KernelSDKIntentService.class);
         intent.setAction(ACTION_START_SCENARIO);
         intent.putExtra(EXTRA_USE_CASE_ID, useCaseId);
+        intent.putExtra(YOTI_CALLED_RESULT_RECEIVER, resultReceiver);
         context.startService(intent);
     }
 
@@ -82,12 +85,13 @@ public class KernelSDKIntentService extends IntentService {
             if (ACTION_BACKEND_CALL.equals(action)) {
                 handleActionBackendCall(useCaseId);
             } else if (ACTION_START_SCENARIO.equals(action)) {
-                handleActionStartScenario(useCaseId);
+                ResultReceiver resultReceiver = intent.getParcelableExtra(YOTI_CALLED_RESULT_RECEIVER);
+                handleActionStartScenario(useCaseId, resultReceiver);
             }
         }
     }
 
-    private void handleActionStartScenario(String useCaseId) {
+    private void handleActionStartScenario(String useCaseId, ResultReceiver resultReceiver) {
 
         Scenario currentScenario = YotiSDK.getScenario(useCaseId);
 
@@ -122,6 +126,8 @@ public class KernelSDKIntentService extends IntentService {
                 .appendQueryParameter(APP_ID_PARAM, getPackageName())
                 .appendQueryParameter(APP_NAME_PARAM, appName)
                 .build();
+
+        resultReceiver.send(0, null);
 
         Intent intent = new Intent(Intent.ACTION_VIEW, uri);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/yoti-sdk/src/test/java/com/yoti/mobile/android/sdk/YotiSDKTest.java
+++ b/yoti-sdk/src/test/java/com/yoti/mobile/android/sdk/YotiSDKTest.java
@@ -59,7 +59,7 @@ public class YotiSDKTest {
         exception.expect(YotiSDKException.class);
         exception.expectMessage("SDK not initialised");
 
-        YotiSDK.startScenario(mMockContext, "a_scenario", true);
+        YotiSDK.startScenario(mMockContext, "a_scenario", true, null);
     }
 
     @Test
@@ -76,7 +76,7 @@ public class YotiSDKTest {
                 .create();
 
         YotiSDK.addScenario(scenario);
-        YotiSDK.startScenario(mMockContext, "a_scenario", true);
+        YotiSDK.startScenario(mMockContext, "a_scenario", true, null);
     }
 
     @Test
@@ -93,7 +93,7 @@ public class YotiSDKTest {
                 .create();
 
         YotiSDK.addScenario(scenario);
-        YotiSDK.startScenario(mMockContext, "a_scenario", true);
+        YotiSDK.startScenario(mMockContext, "a_scenario", true, null);
     }
 
     @Test
@@ -106,7 +106,7 @@ public class YotiSDKTest {
                 .create();
 
         YotiSDK.addScenario(scenario);
-        YotiSDK.startScenario(mMockContext, "b_scenario", true);
+        YotiSDK.startScenario(mMockContext, "b_scenario", true, null);
     }
 
     @Test
@@ -126,7 +126,7 @@ public class YotiSDKTest {
 
 
         YotiSDK.addScenario(scenario);
-        YotiSDK.startScenario(mMockContext, "a_scenario", true);
+        YotiSDK.startScenario(mMockContext, "a_scenario", true, null);
     }
 
     @Test
@@ -148,7 +148,7 @@ public class YotiSDKTest {
 
 
         YotiSDK.addScenario(scenario);
-        YotiSDK.startScenario(mMockContext, "a_scenario", false);
+        YotiSDK.startScenario(mMockContext, "a_scenario", false, null);
     }
 
     @Test
@@ -168,7 +168,7 @@ public class YotiSDKTest {
 
 
         YotiSDK.addScenario(scenario);
-        YotiSDK.startScenario(mMockContext, "a_scenario", true);
+        YotiSDK.startScenario(mMockContext, "a_scenario", true, null);
     }
 
     @Test
@@ -190,6 +190,6 @@ public class YotiSDKTest {
 
 
         YotiSDK.addScenario(scenario);
-        YotiSDK.startScenario(mMockContext, "a_scenario", false);
+        YotiSDK.startScenario(mMockContext, "a_scenario", false, null);
     }
 }


### PR DESCRIPTION
To notify the 3rd party app that the call to Yoti has been done.
Fixing tests dependency issue.

[ED-553](https://lampkicking.atlassian.net/browse/ED-553)

**Tests**

- [ ] YotiCalled callback works
- Install the Sample App
- Click on "Share my phone" button
- When the Yoti app is opened tap in recents button, go back to the Sample app and check that there is no loader spinner and the button is enabled.