### PR TITLE
[BUG][ED-623] Move scenario initialisation to the application onCreate

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ We have included both config below :
 [See this code in one of our sample apps](./sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/ShareAttributesResultBroadcastReceiver.java)
 
 
-You will now need to specify your Client SDK ID and Scenario ID ready from your application dashboard.
+You will now need to specify your Client SDK ID and Scenario ID from your application dashboard.
 The SDK can be initialised like this:
 
 
@@ -157,7 +157,8 @@ try {
 YotiSDK.addScenario(scenario);
 ```
 
-[See this code in one of our sample apps](./sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/MainActivity.java)
+It is very important that this initialisation is done in the onCreate method fo your Application.
+[See this code in one of our sample apps](./sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/SampleApp.java)
 
 In order to set a listener for the events on the Yoti button you can specify one this way:
 

--- a/sample-app-2/src/main/AndroidManifest.xml
+++ b/sample-app-2/src/main/AndroidManifest.xml
@@ -3,13 +3,16 @@
     package="com.yoti.sampleapp2">
 
     <uses-permission android:name="android.permission.INTERNET" />
+
     <application
+        android:name="com.yoti.mobile.android.sampleapp2.SampleApp2"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+
         <activity android:name="com.yoti.mobile.android.sampleapp2.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/MainActivity.java
+++ b/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/MainActivity.java
@@ -6,11 +6,8 @@ import android.view.View;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import com.yoti.mobile.android.sdk.YotiSDK;
 import com.yoti.mobile.android.sdk.YotiSDKButton;
 import com.yoti.mobile.android.sdk.exceptions.YotiSDKException;
-import com.yoti.mobile.android.sdk.exceptions.YotiSDKNotValidScenarioException;
-import com.yoti.mobile.android.sdk.model.Scenario;
 import com.yoti.sampleapp2.R;
 
 public class MainActivity extends AppCompatActivity {
@@ -23,8 +20,6 @@ public class MainActivity extends AppCompatActivity {
         final YotiSDKButton yotiSDKButton = findViewById(R.id.yoti_button);
         final ProgressBar progress = findViewById(R.id.progress);
         final TextView message = findViewById(R.id.text);
-
-        createYoti();
 
         yotiSDKButton.setOnYotiScenarioListener(new YotiSDKButton.OnYotiButtonClickListener() {
             @Override
@@ -41,23 +36,6 @@ public class MainActivity extends AppCompatActivity {
                 message.setText(R.string.loc_error_unknow);
             }
         });
-    }
-
-
-    private void createYoti() {
-        Scenario scenario = null;
-        try {
-            scenario = new Scenario.Builder()
-                    .setUseCaseId("yoti_btn_1")
-                    .setClientSDKId("d28feaf4-d62d-40e3-88ae-d619e9a5b906")
-                    .setScenarioId("60b8e997-4a5c-40b2-86e8-29c4521b7015")
-                    .setCallbackAction("com.yoti.services.CALLBACK")
-                    .create();
-        } catch (YotiSDKNotValidScenarioException e) {
-            e.printStackTrace();
-        }
-
-        YotiSDK.addScenario(scenario);
     }
 
 }

--- a/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/SampleApp2.java
+++ b/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/SampleApp2.java
@@ -1,0 +1,30 @@
+package com.yoti.mobile.android.sampleapp2;
+
+import android.app.Application;
+
+import com.yoti.mobile.android.sdk.YotiSDK;
+import com.yoti.mobile.android.sdk.exceptions.YotiSDKNotValidScenarioException;
+import com.yoti.mobile.android.sdk.model.Scenario;
+
+public class SampleApp2 extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        Scenario scenario = null;
+
+        try {
+            scenario = new Scenario.Builder()
+                    .setUseCaseId("yoti_btn_1")
+                    .setClientSDKId("d28feaf4-d62d-40e3-88ae-d619e9a5b906")
+                    .setScenarioId("60b8e997-4a5c-40b2-86e8-29c4521b7015")
+                    .setCallbackAction("com.yoti.services.CALLBACK")
+                    .create();
+        } catch (YotiSDKNotValidScenarioException e) {
+            e.printStackTrace();
+        }
+
+        YotiSDK.addScenario(scenario);
+    }
+}

--- a/sample-app/src/main/AndroidManifest.xml
+++ b/sample-app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".SampleApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/MainActivity.java
+++ b/sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/MainActivity.java
@@ -2,18 +2,13 @@ package com.yoti.mobile.android.sdk.sampleapp;
 
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import com.yoti.mobile.android.sdk.YotiSDKButton;
-import com.yoti.mobile.android.sdk.YotiSDK;
 import com.yoti.mobile.android.sdk.exceptions.YotiSDKException;
 import com.yoti.mobile.android.sdk.exceptions.YotiSDKNoYotiAppException;
-import com.yoti.mobile.android.sdk.exceptions.YotiSDKNotValidScenarioException;
-import com.yoti.mobile.android.sdk.model.CustomCertificate;
-import com.yoti.mobile.android.sdk.model.Scenario;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -24,8 +19,6 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_main);
-
-        setupYotiShareScenario();
 
         final YotiSDKButton yotiSDKButton = (YotiSDKButton) findViewById(R.id.button);
         final ProgressBar progress = (ProgressBar) findViewById(R.id.progress);
@@ -72,30 +65,4 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    private void setupYotiShareScenario() {
-        CustomCertificate customCertificate = new CustomCertificate();
-        customCertificate.setCertificateResourceId(R.raw.certificate);
-        customCertificate.setAlias("test");
-        customCertificate.setPassword("test123");
-        customCertificate.setStoreName("TEST");
-
-        try {
-            Scenario scenario = new Scenario.Builder()
-                    .setUseCaseId("get_user_phone_1")
-                    .setClientSDKId("4c5ecbe4-dbc1-4e42-9a36-7fc81dd32bea")
-                    .setScenarioId("35e0cf80-c8dc-4dd3-ac66-023d2c2e496c")
-                    .setCallbackAction("com.test.app.YOTI_CALLBACK")
-                    .setBackendCallbackAction("com.test.app.BACKEND_CALLBACK")
-                    .setCustomCertificate(customCertificate)
-                    .create();
-
-            YotiSDK.addScenario(scenario);
-
-            YotiSDK.enableSDKLogging(true);
-
-        } catch (YotiSDKNotValidScenarioException e) {
-            Log.e(TAG, "Invalid scenario!!", e);
-        }
-
-    }
 }

--- a/sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/SampleApp.java
+++ b/sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/SampleApp.java
@@ -1,0 +1,43 @@
+package com.yoti.mobile.android.sdk.sampleapp;
+
+import android.app.Application;
+import android.util.Log;
+
+import com.yoti.mobile.android.sdk.YotiSDK;
+import com.yoti.mobile.android.sdk.exceptions.YotiSDKNotValidScenarioException;
+import com.yoti.mobile.android.sdk.model.CustomCertificate;
+import com.yoti.mobile.android.sdk.model.Scenario;
+
+import static android.content.ContentValues.TAG;
+
+public class SampleApp extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        CustomCertificate customCertificate = new CustomCertificate();
+        customCertificate.setCertificateResourceId(R.raw.certificate);
+        customCertificate.setAlias("test");
+        customCertificate.setPassword("test123");
+        customCertificate.setStoreName("TEST");
+
+        try {
+            Scenario scenario = new Scenario.Builder()
+                    .setUseCaseId("get_user_phone_1")
+                    .setClientSDKId("d10b19d3-fa50-48ab-bd8c-f5a099205e6c")
+                    .setScenarioId("17807359-a933-4b77-baa2-3c2fdb5608f2")
+                    .setCallbackAction("com.test.app.YOTI_CALLBACK")
+                    .setBackendCallbackAction("com.test.app.BACKEND_CALLBACK")
+                    .setCustomCertificate(customCertificate)
+                    .create();
+
+            YotiSDK.addScenario(scenario);
+
+            YotiSDK.enableSDKLogging(true);
+
+        } catch (YotiSDKNotValidScenarioException e) {
+            Log.e(TAG, "Invalid scenario!!", e);
+        }
+    }
+}


### PR DESCRIPTION
At the moment the initialisation of the scenarios in the 3rd party app occurs in the onCreate of their Activity, which means that when the app is killed, that information gets lost.
Then the Intent coming from the Yoti app, wakes app the app, but the onCreate of the Activity is not called, therefore the SDK don't have the scenarios set up to continue with the process.

To solve this, we are moving the initialisation of the Scenarios in the SDK to the onCreate of the application itself.

[ED-623](https://lampkicking.atlassian.net/browse/ED-623)

**Tests**

- [ ] Check data is not lost
- Install Sample app
- Click on the "Share my phone" button
- When the Yoti app is open, click in the recents button and kill the Sample app
- Go back to Yoti and complete the share
- Check that we have receive the result of the share successfully
