### PR TITLE
[ED-545] Forcing Yoti app to be opened when Yoti SDK button is pressed.

### DIFF
--- a/sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/MainActivity.java
+++ b/sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/MainActivity.java
@@ -44,6 +44,9 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onYotiAppNotInstalledError(YotiSDKNoYotiAppException cause) {
                 //The Yoti app is not installed, let's deal with it
+                yotiSDKButton.setVisibility(View.VISIBLE);
+                progress.setVisibility(View.GONE);
+                message.setText(R.string.loc_no_yoti_app_error);
             }
         });
 

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="share_my_phone">Share my phone</string>
 
     <string name="loc_error_unknow">Something went wrong :(</string>
+    <string name="loc_no_yoti_app_error">The Yoti app is not install in this device</string>
     <string name="loc_error_not_completed_on_yoti">Process not completed on the Yoti App</string>
     <string name="loc_phone_number">Your phone number is : %s</string>
 </resources>

--- a/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/YotiSDKButton.java
+++ b/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/YotiSDKButton.java
@@ -104,12 +104,10 @@ public class YotiSDKButton extends YotiButton implements View.OnClickListener {
 
             YotiSDKLogger.error(cause.getMessage(), cause);
 
-            if (mOnYotiButtonClickListener != null) {
-                mOnYotiButtonClickListener.onStartScenarioError(cause);
-            }
-
             if (mOnYotiAppNotInstalledListener != null && cause instanceof YotiSDKNoYotiAppException) {
                 mOnYotiAppNotInstalledListener.onYotiAppNotInstalledError((YotiSDKNoYotiAppException) cause);
+            } else if (mOnYotiButtonClickListener != null) {
+                mOnYotiButtonClickListener.onStartScenarioError(cause);
             }
         }
     }

--- a/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/kernelSDK/KernelSDKIntentService.java
+++ b/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/kernelSDK/KernelSDKIntentService.java
@@ -17,6 +17,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 
+import static com.yoti.mobile.android.sdk.YotiAppDefs.YOTI_APP_PACKAGE;
 import static com.yoti.mobile.android.sdk.YotiSDKDefs.APP_ID_PARAM;
 import static com.yoti.mobile.android.sdk.YotiSDKDefs.APP_NAME_PARAM;
 import static com.yoti.mobile.android.sdk.YotiSDKDefs.CALLBACK_PARAM;
@@ -123,7 +124,16 @@ public class KernelSDKIntentService extends IntentService {
                 .appendQueryParameter(APP_NAME_PARAM, appName)
                 .build();
 
-        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        Intent intent;
+        intent = getPackageManager().getLaunchIntentForPackage(YOTI_APP_PACKAGE);
+
+        if (intent == null) {
+            // Yoti app is not installed, let's open the website
+            intent = new Intent(Intent.ACTION_VIEW, uri);
+        } else {
+            intent.setData(uri);
+        }
+
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         startActivity(intent);
     }


### PR DESCRIPTION
With this change we are hoping to avoid the user clicking the browser on the app chooser dialog, which could be the reason of the behaviour seen for this ticket.

[https://lampkicking.atlassian.net/browse/ED-545](https://lampkicking.atlassian.net/browse/ED-545)

ED-545

*Verification Tests*

- [x] Yoti app not installed -> website
- Make sure Yoti is not installed
- Install the SampleApp2
- Click on the "Share my phone" button
- Check that the website is showed

- [x] Yoti app installed -> Yoti
- Install Yoti app
- Open the SampleApp2
- Click on the "Share my phone" button
- Check that the Yoti app is opened and show the share confirm screen

@lampkicking/android-dev