### PR TITLE
[ED-718] Bringing 3rd party app to the foreground after Yoti share completion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ We have included both config below :
 ```
 [See this code in one of our sample apps](./sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/ShareAttributesResultBroadcastReceiver.java)
 
+Once you have received the intent from the Yoti app you should start one of your activities so that
+your app goes back to the foreground and the user can continue with the flow within your app.
+
+[Check our Sample-app2 to see an example of how this can be done.](./sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/recievers/ShareAttributesResultBroadcastReceiver.java)
+
 
 You will now need to specify your Client SDK ID and Scenario ID from your application dashboard.
 The SDK can be initialised like this:

--- a/sample-app-2/src/main/AndroidManifest.xml
+++ b/sample-app-2/src/main/AndroidManifest.xml
@@ -13,7 +13,9 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
-        <activity android:name="com.yoti.mobile.android.sampleapp2.MainActivity">
+        <activity
+            android:name="com.yoti.mobile.android.sampleapp2.MainActivity"
+            android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/MainActivity.java
+++ b/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/MainActivity.java
@@ -1,5 +1,6 @@
 package com.yoti.mobile.android.sampleapp2;
 
+import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.View;
@@ -10,16 +11,26 @@ import com.yoti.mobile.android.sdk.YotiSDKButton;
 import com.yoti.mobile.android.sdk.exceptions.YotiSDKException;
 import com.yoti.sampleapp2.R;
 
+import static com.yoti.mobile.android.sampleapp2.ProfileActivity.PROFILE_EXTRA;
+
 public class MainActivity extends AppCompatActivity {
+
+    public static final String LOADING_STATUS = "com.yoti.mobile.android.sampleapp2.LOADING_STATUS";
+
+    private YotiSDKButton yotiSDKButton;
+    private ProgressBar progress;
+    private TextView message;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        final YotiSDKButton yotiSDKButton = findViewById(R.id.yoti_button);
-        final ProgressBar progress = findViewById(R.id.progress);
-        final TextView message = findViewById(R.id.text);
+        yotiSDKButton = findViewById(R.id.yoti_button);
+        progress = findViewById(R.id.progress);
+        message = findViewById(R.id.text);
+
+        processExtraData(getIntent());
 
         yotiSDKButton.setOnYotiScenarioListener(new YotiSDKButton.OnYotiButtonClickListener() {
             @Override
@@ -38,6 +49,31 @@ public class MainActivity extends AppCompatActivity {
         });
     }
 
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        processExtraData(intent);
+    }
+
+    private void processExtraData(Intent intent) {
+
+        if (intent.getBooleanExtra(LOADING_STATUS, false)) {
+            //Set up UI loading status
+            yotiSDKButton.setVisibility(View.GONE);
+            progress.setVisibility(View.VISIBLE);
+            message.setText(R.string.loc_loading_message);
+
+        } else if (intent.getBooleanExtra(PROFILE_EXTRA, false)) {
+            //Start activity that presents the profile
+            Intent profileIntent = new Intent(this, ProfileActivity.class);
+            profileIntent.putExtras(intent.getExtras());
+            startActivity(profileIntent);
+
+            // Restore UI
+            yotiSDKButton.setVisibility(View.VISIBLE);
+            progress.setVisibility(View.GONE);
+            message.setText("");
+        }
+    }
 }
-
-

--- a/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/ProfileActivity.java
+++ b/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/ProfileActivity.java
@@ -19,6 +19,7 @@ public class ProfileActivity extends AppCompatActivity {
     public static final String ADDRESS_EXTRA = "com.yoti.services.ADDRESS_EXTRA";
     public static final String MOBILE_EXTRA = "com.yoti.services.MOBILE_EXTRA";
     public static final String GENDER_EXTRA = "com.yoti.services.GENDER_EXTRA";
+    public static final String PROFILE_EXTRA = "com.yoti.services.PROFILE_EXTRA";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/recievers/ShareAttributesResultBroadcastReceiver.java
+++ b/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/recievers/ShareAttributesResultBroadcastReceiver.java
@@ -1,6 +1,7 @@
 package com.yoti.mobile.android.sampleapp2.recievers;
 
 
+import android.content.Context;
 import android.content.Intent;
 
 import com.yoti.mobile.android.sampleapp2.MainActivity;
@@ -19,8 +20,16 @@ public class ShareAttributesResultBroadcastReceiver extends AbstractShareAttribu
     public static final String EXTRA_CANCELLED_BY_USER = "com.yoti.mobile.android.sdk.EXTRA_CANCELLED_BY_USER";
 
     @Override
-    public boolean onCallbackReceived(String useCaseId, String callbackRoot, String token, String fullUrl) {
+    public void onReceive(Context context, Intent intent) {
+        super.onReceive(context, intent);
+        //Start our activity so the app comes back to the foreground
+        Intent myActivityIntent = new Intent(mContext, MainActivity.class);
+        myActivityIntent.putExtra(MainActivity.LOADING_STATUS, true);
+        mContext.startActivity(myActivityIntent);
+    }
 
+    @Override
+    public boolean onCallbackReceived(String useCaseId, String callbackRoot, String token, String fullUrl) {
         CallbackIntentService.startActionRetrieveProfile(this.mContext, useCaseId, callbackRoot, token, fullUrl);
 
         return true;

--- a/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/services/CallbackIntentService.java
+++ b/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/services/CallbackIntentService.java
@@ -7,7 +7,7 @@ import android.util.Log;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.yoti.mobile.android.sampleapp2.ProfileActivity;
+import com.yoti.mobile.android.sampleapp2.MainActivity;
 import com.yoti.mobile.android.sampleapp2.model.Profile;
 
 import java.io.ByteArrayOutputStream;
@@ -24,6 +24,7 @@ import static com.yoti.mobile.android.sampleapp2.ProfileActivity.GENDER_EXTRA;
 import static com.yoti.mobile.android.sampleapp2.ProfileActivity.IMAGE_EXTRA;
 import static com.yoti.mobile.android.sampleapp2.ProfileActivity.MOBILE_EXTRA;
 import static com.yoti.mobile.android.sampleapp2.ProfileActivity.NAME_EXTRA;
+import static com.yoti.mobile.android.sampleapp2.ProfileActivity.PROFILE_EXTRA;
 
 /**
  * An {@link IntentService} subclass for handling the call to the backend.
@@ -92,7 +93,7 @@ public class CallbackIntentService extends IntentService {
         Gson g = new GsonBuilder().create();
         Profile profile = g.fromJson(new String(response), Profile.class);
 
-        Intent intent = new Intent(this, ProfileActivity.class);
+        Intent intent = new Intent(this, MainActivity.class);
         intent.putExtra(NAME_EXTRA, profile.getGivenNames() + " " + profile.getFamilyName());
         intent.putExtra(EMAIL_EXTRA, profile.getEmailAddress());
         intent.putExtra(IMAGE_EXTRA, profile.getSelfie());
@@ -100,6 +101,7 @@ public class CallbackIntentService extends IntentService {
         intent.putExtra(ADDRESS_EXTRA, profile.getPostalAddress());
         intent.putExtra(MOBILE_EXTRA, profile.getMobNum());
         intent.putExtra(GENDER_EXTRA, profile.getGender());
+        intent.putExtra(PROFILE_EXTRA, true);
         startActivity(intent);
 
     }

--- a/sample-app-2/src/main/res/values/strings.xml
+++ b/sample-app-2/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">Yoti Android-SDK-Demo</string>
     <string name="loc_error_unknow">Something went wrong :(</string>
+    <string name="loc_loading_message">Retrieving your data...</string>
 </resources>


### PR DESCRIPTION
- Added comment in Readme file.
- Implemented it in Sample app 2.

[ED-718](https://lampkicking.atlassian.net/browse/ED-718)

**Testing**

- Open sample app 2
- Click in the Yoti button
- Complete the share in the Yoti app
- Check that once the share is complete you go back to the sample app in a loading state that will move to the profile screen when the data is received from the backend.