### PR TITLE
[TASK][YM-15454]  Using pending intent so we get waken up when share is done

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,8 +32,8 @@ supportLibraryVersion=25.3.1
 libJunitVersion=4.12
 libMockitoVersion=1.10.19
 
-currentVersion=1.0.0
-currentVersionCode=000007
+currentVersion=1.1.0
+currentVersionCode=000008
 currentAppName=Mobile Button SDK
 artefactName=yoti-button-sdk
 

--- a/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/MainActivity.java
+++ b/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/MainActivity.java
@@ -11,6 +11,7 @@ import com.yoti.mobile.android.sdk.YotiSDKButton;
 import com.yoti.mobile.android.sdk.exceptions.YotiSDKException;
 import com.yoti.sampleapp2.R;
 
+import static com.yoti.mobile.android.sampleapp2.ProfileActivity.BACKEND_DATA_ERROR_EXTRA;
 import static com.yoti.mobile.android.sampleapp2.ProfileActivity.PROFILE_EXTRA;
 
 public class MainActivity extends AppCompatActivity {
@@ -74,6 +75,11 @@ public class MainActivity extends AppCompatActivity {
             yotiSDKButton.setVisibility(View.VISIBLE);
             progress.setVisibility(View.GONE);
             message.setText("");
+
+        } else if (intent.getBooleanExtra(BACKEND_DATA_ERROR_EXTRA, false)) {
+            yotiSDKButton.setVisibility(View.GONE);
+            progress.setVisibility(View.GONE);
+            message.setText(R.string.loc_error_processing_backend_response);
         }
     }
 }

--- a/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/ProfileActivity.java
+++ b/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/ProfileActivity.java
@@ -20,6 +20,7 @@ public class ProfileActivity extends AppCompatActivity {
     public static final String MOBILE_EXTRA = "com.yoti.services.MOBILE_EXTRA";
     public static final String GENDER_EXTRA = "com.yoti.services.GENDER_EXTRA";
     public static final String PROFILE_EXTRA = "com.yoti.services.PROFILE_EXTRA";
+    public static final String BACKEND_DATA_ERROR_EXTRA = "com.yoti.services.BACKEND_DATA_ERROR_EXTRA";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/services/CallbackIntentService.java
+++ b/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/services/CallbackIntentService.java
@@ -18,6 +18,7 @@ import java.net.URL;
 import javax.net.ssl.HttpsURLConnection;
 
 import static com.yoti.mobile.android.sampleapp2.ProfileActivity.ADDRESS_EXTRA;
+import static com.yoti.mobile.android.sampleapp2.ProfileActivity.BACKEND_DATA_ERROR_EXTRA;
 import static com.yoti.mobile.android.sampleapp2.ProfileActivity.DOB_EXTRA;
 import static com.yoti.mobile.android.sampleapp2.ProfileActivity.EMAIL_EXTRA;
 import static com.yoti.mobile.android.sampleapp2.ProfileActivity.GENDER_EXTRA;
@@ -91,18 +92,25 @@ public class CallbackIntentService extends IntentService {
         }
 
         Gson g = new GsonBuilder().create();
-        Profile profile = g.fromJson(new String(response), Profile.class);
 
-        Intent intent = new Intent(this, MainActivity.class);
-        intent.putExtra(NAME_EXTRA, profile.getGivenNames() + " " + profile.getFamilyName());
-        intent.putExtra(EMAIL_EXTRA, profile.getEmailAddress());
-        intent.putExtra(IMAGE_EXTRA, profile.getSelfie());
-        intent.putExtra(DOB_EXTRA, profile.getDateOfBirth());
-        intent.putExtra(ADDRESS_EXTRA, profile.getPostalAddress());
-        intent.putExtra(MOBILE_EXTRA, profile.getMobNum());
-        intent.putExtra(GENDER_EXTRA, profile.getGender());
-        intent.putExtra(PROFILE_EXTRA, true);
-        startActivity(intent);
+        try {
+            Profile profile = g.fromJson(new String(response), Profile.class);
+
+            Intent intent = new Intent(this, MainActivity.class);
+            intent.putExtra(NAME_EXTRA, profile.getGivenNames() + " " + profile.getFamilyName());
+            intent.putExtra(EMAIL_EXTRA, profile.getEmailAddress());
+            intent.putExtra(IMAGE_EXTRA, profile.getSelfie());
+            intent.putExtra(DOB_EXTRA, profile.getDateOfBirth());
+            intent.putExtra(ADDRESS_EXTRA, profile.getPostalAddress());
+            intent.putExtra(MOBILE_EXTRA, profile.getMobNum());
+            intent.putExtra(GENDER_EXTRA, profile.getGender());
+            intent.putExtra(PROFILE_EXTRA, true);
+            startActivity(intent);
+        } catch (Exception e) {
+            Intent intent = new Intent(this, MainActivity.class);
+            intent.putExtra(BACKEND_DATA_ERROR_EXTRA, true);
+            startActivity(intent);
+        }
 
     }
 

--- a/sample-app-2/src/main/res/values/strings.xml
+++ b/sample-app-2/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">Yoti Android-SDK-Demo</string>
     <string name="loc_error_unknow">Something went wrong :(</string>
     <string name="loc_loading_message">Retrieving your data...</string>
+    <string name="loc_error_processing_backend_response">There was an error processing the response from the backend but all the SDK functionality went well!</string>
 </resources>

--- a/sample-app/src/main/AndroidManifest.xml
+++ b/sample-app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/MainActivity.java
+++ b/sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/MainActivity.java
@@ -1,5 +1,6 @@
 package com.yoti.mobile.android.sdk.sampleapp;
 
+import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.View;
@@ -14,67 +15,85 @@ public class MainActivity extends AppCompatActivity {
 
     private static final String TAG = MainActivity.class.getSimpleName();
 
+    private YotiSDKButton mYotiSDKButton;
+    private ProgressBar mProgress;
+    private TextView mMessage;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_main);
 
-        final YotiSDKButton yotiSDKButton = (YotiSDKButton) findViewById(R.id.button);
-        final ProgressBar progress = (ProgressBar) findViewById(R.id.progress);
-        final TextView message = (TextView)findViewById(R.id.text);
+        mYotiSDKButton = (YotiSDKButton) findViewById(R.id.button);
+        mProgress = (ProgressBar) findViewById(R.id.progress);
+        mMessage = (TextView)findViewById(R.id.text);
 
-        yotiSDKButton.setOnYotiButtonClickListener(new YotiSDKButton.OnYotiButtonClickListener() {
+        mYotiSDKButton.setOnYotiButtonClickListener(new YotiSDKButton.OnYotiButtonClickListener() {
             @Override
             public void onStartScenario() {
-                yotiSDKButton.setVisibility(View.GONE);
-                progress.setVisibility(View.VISIBLE);
-                message.setText(null);
+                mYotiSDKButton.setVisibility(View.GONE);
+                mProgress.setVisibility(View.VISIBLE);
+                mMessage.setText(null);
             }
 
             @Override
             public void onStartScenarioError(YotiSDKException cause) {
-                yotiSDKButton.setVisibility(View.VISIBLE);
-                progress.setVisibility(View.GONE);
-                message.setText(R.string.loc_error_unknow);
+                mYotiSDKButton.setVisibility(View.VISIBLE);
+                mProgress.setVisibility(View.GONE);
+                mMessage.setText(R.string.loc_error_unknow);
             }
         });
 
-        yotiSDKButton.setOnYotiAppNotInstalledListener(new YotiSDKButton.OnYotiAppNotInstalledListener() {
+        mYotiSDKButton.setOnYotiAppNotInstalledListener(new YotiSDKButton.OnYotiAppNotInstalledListener() {
             @Override
             public void onYotiAppNotInstalledError(YotiSDKNoYotiAppException cause) {
                 //The Yoti app is not installed, let's deal with it
-                yotiSDKButton.setVisibility(View.VISIBLE);
-                progress.setVisibility(View.GONE);
-                message.setText(R.string.loc_no_yoti_app_error);
+                mYotiSDKButton.setVisibility(View.VISIBLE);
+                mProgress.setVisibility(View.GONE);
+                mMessage.setText(R.string.loc_no_yoti_app_error);
             }
         });
 
-        yotiSDKButton.setOnYotiCalledListener(new YotiSDKButton.OnYotiCalledListener() {
+        mYotiSDKButton.setOnYotiCalledListener(new YotiSDKButton.OnYotiCalledListener() {
             @Override
             public void onYotiCalled() {
                 // Restore the original state
-                yotiSDKButton.setVisibility(View.VISIBLE);
-                progress.setVisibility(View.GONE);
+                mYotiSDKButton.setVisibility(View.VISIBLE);
+                mProgress.setVisibility(View.GONE);
             }
         });
-
-        if (getIntent().hasExtra(ShareAttributesResultBroadcastReceiver.EXTRA_CANCELLED_BY_USER)) {
-            yotiSDKButton.setVisibility(View.VISIBLE);
-            progress.setVisibility(View.GONE);
-            message.setText(R.string.loc_error_not_completed_on_yoti);
-        }
-
-        if (getIntent().hasExtra(ShareAttributesResultBroadcastReceiver.EXTRA_IS_FAILED)) {
-            yotiSDKButton.setVisibility(View.VISIBLE);
-            progress.setVisibility(View.GONE);
-            message.setText(R.string.loc_error_unknow);
-        }
-
-        if (getIntent().hasExtra(ShareAttributesResultBroadcastReceiver.EXTRA_RESPONSE)) {
-            String phone = getIntent().getStringExtra(ShareAttributesResultBroadcastReceiver.EXTRA_RESPONSE);
-            message.setText(String.format(getString(R.string.loc_phone_number), phone));
-        }
     }
 
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        processExtraData(intent);
+    }
+
+    private void processExtraData(Intent intent) {
+        if (intent.hasExtra(ShareAttributesResultBroadcastReceiver.EXTRA_CANCELLED_BY_USER)) {
+            mYotiSDKButton.setVisibility(View.VISIBLE);
+            mProgress.setVisibility(View.GONE);
+            mMessage.setText(R.string.loc_error_not_completed_on_yoti);
+        }
+
+        if (intent.hasExtra(ShareAttributesResultBroadcastReceiver.EXTRA_IS_FAILED)) {
+            mYotiSDKButton.setVisibility(View.VISIBLE);
+            mProgress.setVisibility(View.GONE);
+            mMessage.setText(R.string.loc_error_unknow);
+        }
+
+        if (intent.hasExtra(ShareAttributesResultBroadcastReceiver.EXTRA_RESPONSE)) {
+            String response = getIntent().getStringExtra(ShareAttributesResultBroadcastReceiver.EXTRA_RESPONSE);
+            if (response != null) {
+                mMessage.setText(R.string.loc_success_status);
+            }
+        }
+
+        if (intent.hasExtra(ShareAttributesResultBroadcastReceiver.EXTRA_LOADING)) {
+            mMessage.setText(R.string.loc_loading_status);
+        }
+    }
 }

--- a/sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/ShareAttributesResultBroadcastReceiver.java
+++ b/sample-app/src/main/java/com/yoti/mobile/android/sdk/sampleapp/ShareAttributesResultBroadcastReceiver.java
@@ -17,9 +17,14 @@ public class ShareAttributesResultBroadcastReceiver extends AbstractShareAttribu
     public static final String EXTRA_CANCELLED_BY_USER = "com.yoti.mobile.android.sdk.EXTRA_CANCELLED_BY_USER";
     public static final String EXTRA_IS_FAILED = "com.yoti.mobile.android.sdk.EXTRA_IS_FAILED";
     public static final String EXTRA_RESPONSE = "com.yoti.mobile.android.sdk.EXTRA_RESPONSE";
+    public static final String EXTRA_LOADING = "com.yoti.mobile.android.sdk.EXTRA_LOADING";
 
     @Override
     public boolean onCallbackReceived(String useCaseId, String callbackRoot, String token, String fullUrl) {
+        Intent intent = new Intent(mContext, MainActivity.class);
+        intent.putExtra(EXTRA_LOADING, true);
+        intent.addFlags(FLAG_ACTIVITY_NEW_TASK);
+        mContext.startActivity(intent);
         return false;
     }
 

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -7,4 +7,6 @@
     <string name="loc_no_yoti_app_error">The Yoti app is not install in this device</string>
     <string name="loc_error_not_completed_on_yoti">Process not completed on the Yoti App</string>
     <string name="loc_phone_number">Your phone number is : %s</string>
+    <string name="loc_success_status">Success!!</string>
+    <string name="loc_loading_status">Loading...</string>
 </resources>

--- a/yoti-sdk/src/main/AndroidManifest.xml
+++ b/yoti-sdk/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
         android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true">
+        <activity android:name=".ReceiverActivity" android:theme="@style/Theme.AppCompat.Translucent"/>
         <service
             android:name=".kernelSDK.KernelSDKIntentService"
             android:exported="false"/>

--- a/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/ReceiverActivity.java
+++ b/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/ReceiverActivity.java
@@ -1,0 +1,21 @@
+package com.yoti.mobile.android.sdk;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+
+public class ReceiverActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Intent intent = new Intent(getIntent().getAction());
+        intent.setPackage(getIntent().getPackage());
+        intent.putExtras(getIntent().getExtras());
+
+        sendBroadcast(intent);
+
+        finish();
+    }
+}

--- a/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/kernelSDK/EnvironmentConfiguration.java
+++ b/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/kernelSDK/EnvironmentConfiguration.java
@@ -5,10 +5,6 @@ package com.yoti.mobile.android.sdk.kernelSDK;
  */
 public class EnvironmentConfiguration {
 
-    static final String YOTI_PUBLIC_KEYSTORE_PWD = "W?9zvT%a(KU#L&V~";
-    static final String YOTI_PUBLIC_KEYSTORE_ALIAS = "sdk_prod";
-    final static String YOTI_PUBLIC_KEYSTORE = "yoti.sdk.keystore";
-
     private final static String HOST_CONNECT_API = "https://api.yoti.com";
     private final static String CONNECT_API_PORT = "443";
 

--- a/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/kernelSDK/KernelSDK.java
+++ b/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/kernelSDK/KernelSDK.java
@@ -61,7 +61,7 @@ public class KernelSDK {
                 YotiSDKLogger.warning("ICallbackBackendListener is null");
             }
 
-        } catch (IOException e) {
+        } catch (Exception e) {
             if (listener != null) {
                 listener.onError(-1, e, null);
             } else {

--- a/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/kernelSDK/KernelSDKIntentService.java
+++ b/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/kernelSDK/KernelSDKIntentService.java
@@ -1,6 +1,7 @@
 package com.yoti.mobile.android.sdk.kernelSDK;
 
 import android.app.IntentService;
+import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
@@ -8,15 +9,12 @@ import android.net.Uri;
 import android.os.ResultReceiver;
 import android.text.TextUtils;
 
+import com.yoti.mobile.android.sdk.ReceiverActivity;
 import com.yoti.mobile.android.sdk.YotiSDK;
 import com.yoti.mobile.android.sdk.YotiSDKLogger;
 import com.yoti.mobile.android.sdk.model.Scenario;
 
 import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 
 import static com.yoti.mobile.android.sdk.YotiAppDefs.YOTI_APP_PACKAGE;
 import static com.yoti.mobile.android.sdk.YotiSDKDefs.APP_ID_PARAM;
@@ -38,6 +36,7 @@ public class KernelSDKIntentService extends IntentService {
     private static final String ACTION_BACKEND_CALL = "com.yoti.mobile.android.sdk.network.action.BACKEND_CALL";
     private static final String ACTION_START_SCENARIO = "com.yoti.mobile.android.sdk.network.action.START_SCENARIO";
     private static final String YOTI_CALLED_RESULT_RECEIVER = "com.yoti.mobile.android.sdk.network.action.YOTI_CALLED_RESULT_RECEIVER";
+    public static final String YOTI_PENDING_INTENT_EXTRA = "YOTI_PENDING_INTENT_EXTRA";
 
     private static final String EXTRA_USE_CASE_ID = "com.yoti.mobile.android.sdk.network.extra.USE_CASE_ID";
     private KernelSDK mKernelSDK;
@@ -139,6 +138,11 @@ public class KernelSDKIntentService extends IntentService {
         } else {
             intent.setData(uri);
         }
+
+        Intent wakeupIntent = new Intent(this, ReceiverActivity.class);
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 1, wakeupIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+
+        intent.putExtra(YOTI_PENDING_INTENT_EXTRA, pendingIntent);
 
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         startActivity(intent);

--- a/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/kernelSDK/KernelSDKIntentService.java
+++ b/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/kernelSDK/KernelSDKIntentService.java
@@ -36,7 +36,7 @@ public class KernelSDKIntentService extends IntentService {
     private static final String ACTION_BACKEND_CALL = "com.yoti.mobile.android.sdk.network.action.BACKEND_CALL";
     private static final String ACTION_START_SCENARIO = "com.yoti.mobile.android.sdk.network.action.START_SCENARIO";
     private static final String YOTI_CALLED_RESULT_RECEIVER = "com.yoti.mobile.android.sdk.network.action.YOTI_CALLED_RESULT_RECEIVER";
-    public static final String YOTI_PENDING_INTENT_EXTRA = "YOTI_PENDING_INTENT_EXTRA";
+    public static final String YOTI_PENDING_INTENT_EXTRA = "com.yoti.mobile.android.sdk.network.extra.YOTI_PENDING_INTENT_EXTRA";
 
     private static final String EXTRA_USE_CASE_ID = "com.yoti.mobile.android.sdk.network.extra.USE_CASE_ID";
     private KernelSDK mKernelSDK;

--- a/yoti-sdk/src/main/res/values/styles.xml
+++ b/yoti-sdk/src/main/res/values/styles.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.AppCompat.Translucent" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:background">#00000000</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:colorBackgroundCacheHint">@null</item>
+        <item name="android:windowIsTranslucent">true</item>
+    </style>
+</resources>


### PR DESCRIPTION
The SDK is now going to pass a PendingIntent  to the Yoti app so we can be called back when the share is done.

I have also touch up the sample apps to handle some errors.

JIRA: [YM-15454](https://lampkicking.atlassian.net/browse/YM-15454)

### B&T ### 

- [x] Everything still works
* In one of the sample apps modify the scenarioID and SDKID for staging ones.
* Run the sample app and check the flow it is still ok.

- [x] Works in Android Q
* Get a phone with Android Q (I have one)
* Try the same as the test above


@lampkicking/android-dev
