### PR TITLE
[YD-881][TASK] Small fixes and amends

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ Please start by adding dependencies in the "build.grade" file inside your applic
 
 ```gradle
 dependencies {
-    compile(com.yoti.mobile.android.sdk:yoti-button-sdk:1.0.0)
+    compile(com.yoti.mobile.android.sdk:yoti-button-sdk:1.1.0)
 }
 ```
-OR if you are using a recent version of gradle (>= 3.x):
+OR if you are using a more recent version of gradle (>= 3.x):
 ```gradle
 dependencies {
-    implementation(com.yoti.mobile.android.sdk:yoti-button-sdk:1.0.0)
+    implementation(com.yoti.mobile.android.sdk:yoti-button-sdk:1.1.0)
 }
 ```
 
@@ -84,7 +84,7 @@ The client end of the integration is now complete.
 Add the below configuration to your manifest:
 
 ```xml
-<receiver android:name=".MyBroadcastReceiver">
+<receiver android:name=".MyBroadcastReceiver" android:exported="false">
     <intent-filter>
         <action android:name="YOUR_CALLBACK_ACTION"/>
         <action android:name="YOUR_BACKEND_CALLBACK_ACTION"/>
@@ -93,7 +93,11 @@ Add the below configuration to your manifest:
 ```
 [See this code in one of our sample apps](./sample-app/src/main/AndroidManifest.xml)
 
-Adding this broadcast receiver class, this acts as a listener for Yoti to get the callback URL from the Yoti app. Please note there are two call back options:
+This broadcast receiver was used to receive the communication back from the Yoti App. That's not
+the case in recent versions of the SDK and it is only used internally within your app. Therefore we
+strongly recommend you to declare your receiver with the option exported="false".
+
+Please note there are two call back options:
 
 1) You handle the callback to your backend
 2) Let the SDK manage this for you

--- a/sample-app-2/src/main/AndroidManifest.xml
+++ b/sample-app-2/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
             </intent-filter>
         </activity>
 
-        <receiver android:name="com.yoti.mobile.android.sampleapp2.recievers.ShareAttributesResultBroadcastReceiver">
+        <receiver android:name="com.yoti.mobile.android.sampleapp2.recievers.ShareAttributesResultBroadcastReceiver" android:exported="false">
             <intent-filter>
                 <action android:name="com.yoti.services.CALLBACK" />
             </intent-filter>

--- a/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/recievers/ShareAttributesResultBroadcastReceiver.java
+++ b/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/recievers/ShareAttributesResultBroadcastReceiver.java
@@ -25,6 +25,7 @@ public class ShareAttributesResultBroadcastReceiver extends AbstractShareAttribu
         //Start our activity so the app comes back to the foreground
         Intent myActivityIntent = new Intent(mContext, MainActivity.class);
         myActivityIntent.putExtra(MainActivity.LOADING_STATUS, true);
+        myActivityIntent.addFlags(FLAG_ACTIVITY_NEW_TASK);
         mContext.startActivity(myActivityIntent);
     }
 

--- a/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/services/CallbackIntentService.java
+++ b/sample-app-2/src/main/java/com/yoti/mobile/android/sampleapp2/services/CallbackIntentService.java
@@ -17,6 +17,7 @@ import java.net.URL;
 
 import javax.net.ssl.HttpsURLConnection;
 
+import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;
 import static com.yoti.mobile.android.sampleapp2.ProfileActivity.ADDRESS_EXTRA;
 import static com.yoti.mobile.android.sampleapp2.ProfileActivity.BACKEND_DATA_ERROR_EXTRA;
 import static com.yoti.mobile.android.sampleapp2.ProfileActivity.DOB_EXTRA;
@@ -105,10 +106,12 @@ public class CallbackIntentService extends IntentService {
             intent.putExtra(MOBILE_EXTRA, profile.getMobNum());
             intent.putExtra(GENDER_EXTRA, profile.getGender());
             intent.putExtra(PROFILE_EXTRA, true);
+            intent.addFlags(FLAG_ACTIVITY_NEW_TASK);
             startActivity(intent);
         } catch (Exception e) {
             Intent intent = new Intent(this, MainActivity.class);
             intent.putExtra(BACKEND_DATA_ERROR_EXTRA, true);
+            intent.addFlags(FLAG_ACTIVITY_NEW_TASK);
             startActivity(intent);
         }
 

--- a/sample-app/src/main/AndroidManifest.xml
+++ b/sample-app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
             </intent-filter>
         </activity>
 
-        <receiver android:name=".ShareAttributesResultBroadcastReceiver">
+        <receiver android:name=".ShareAttributesResultBroadcastReceiver" android:exported="false">
             <intent-filter>
                 <action android:name="com.test.app.YOTI_CALLBACK" />
                 <action android:name="com.test.app.BACKEND_CALLBACK" />


### PR DESCRIPTION
Adding FLAG_ACTIVITY_NEW_TASK to the intents that start activities from broadcast receiver
Making broadcast receivers not exported
Amends to the README file

YD-881

B&T
Run both sample apps and check that they still behave properly.