### PR TITLE
Add setter setUseCaseId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.1.2] - 2020-01-16
+### Added
+[(#11)](https://github.com/getyoti/android-sdk-button/pull/11) Added setter `setUseCaseId()` which enables developers to define the useCaseId programatically. Prior to the change, the Use Case ID could only be set statically in the layout file.
+
 ## [1.1.1]
 ### Changed
 Update publication scripts and publish from github actions

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ yoti:useCaseId="YOUR_USE_CASE_ID"/>
 ```
 [See this code in one of our sample apps](./sample-app/src/main/res/layout/activity_main.xml)
 
+Alternatively, you can set the button's useCaseId with:
+```java
+YotiSDKButton.setUseCaseId("YOUR_USE_CASE_ID");
+```
+
 The client end of the integration is now complete.
 
 ## Configuration

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ currentAppName=Mobile Button SDK
 pomId=yoti-button-sdk
 pomGroup=com.yoti.mobile.android.sdk
 pomPackaging=aar
-pomVersion=1.1.1
+pomVersion=1.1.2
 pomDescription=Button SDK that allows 3rd party to trigger Yoti as support app
 currentVersionCode=000008
 

--- a/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/YotiSDKButton.java
+++ b/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/YotiSDKButton.java
@@ -70,6 +70,10 @@ public class YotiSDKButton extends YotiButton implements View.OnClickListener {
         setOnClickListener(this);
     }
 
+    public void setUseCaseId(String useCaseId) {
+        mUseCaseId = useCaseId;
+    }
+    
     private void setLeftRigthPadding(){
         int paddingDp = 8;
         float density = getResources().getDisplayMetrics().density;


### PR DESCRIPTION
Allows better flexibility when creating the button programatically like [in the iOS SDK](https://github.com/getyoti/ios-sdk-button#configuration).
Otherwise the only other way to set the useCaseId would be to create a custom `AttributeSet`.