### PR TITLE
[YM-25652] Update pending intent flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.3.1] - 2022-02-22
+### Changed
+- Update pending intent flags to support Android 12.
+
 ## [1.3.0] - 2021-07-20
 ### Added
 - Added attribute buttonTheme to the YotiSDKButton for applying the theme.

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.4'
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.20.0"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,9 +56,9 @@ easyIDScheme=easyid://
 pomId=yoti-button-sdk
 pomGroup=com.yoti.mobile.android.sdk
 pomPackaging=aar
-pomVersion=1.3.0
+pomVersion=1.3.1
 pomDescription=Button SDK that allows 3rd party to trigger Yoti as support app
-currentVersionCode=000010
+currentVersionCode=000011
 
 pomLicenseName=MIT
 pomLicenseUrl=https://github.com/getyoti/android-sdk-button/blob/master/LICENSE.md

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@
 
 
 minSdkVersionVersion=21
-targetSdkVersion=28
+targetSdkVersion=31
 compileSdkVersion=28
 
 uiWidgetsVersion=1.9.0

--- a/sample-app-2/src/main/AndroidManifest.xml
+++ b/sample-app-2/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
 
         <activity
             android:name="com.yoti.mobile.android.sampleapp2.MainActivity"
+            android:exported="true"
             android:launchMode="singleInstance"
             android:theme="@style/SampleAppFullScreenTheme">
             <intent-filter>
@@ -24,13 +25,17 @@
             </intent-filter>
         </activity>
 
-        <receiver android:name="com.yoti.mobile.android.sampleapp2.recievers.ShareAttributesResultBroadcastReceiver" android:exported="false">
+        <receiver
+            android:name="com.yoti.mobile.android.sampleapp2.recievers.ShareAttributesResultBroadcastReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.yoti.services.CALLBACK" />
             </intent-filter>
         </receiver>
 
-        <activity android:name="com.yoti.mobile.android.sampleapp2.ProfileActivity" />
+        <activity
+            android:name="com.yoti.mobile.android.sampleapp2.ProfileActivity"
+            android:exported="false" />
 
         <service
             android:name="com.yoti.mobile.android.sampleapp2.services.CallbackIntentService"

--- a/sample-app-3/src/main/AndroidManifest.xml
+++ b/sample-app-3/src/main/AndroidManifest.xml
@@ -11,9 +11,11 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name="com.yoti.mobile.android.sdk.sampleapp.MainActivity"
-            android:theme="@style/SampleAppTheme"
-            android:launchMode="singleInstance">
+        <activity
+            android:name="com.yoti.mobile.android.sdk.sampleapp.MainActivity"
+            android:exported="true"
+            android:launchMode="singleInstance"
+            android:theme="@style/SampleAppTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -21,7 +23,9 @@
             </intent-filter>
         </activity>
 
-        <receiver android:name="com.yoti.mobile.android.sdk.sampleapp.ShareAttributesResultBroadcastReceiver" android:exported="false">
+        <receiver
+            android:name="com.yoti.mobile.android.sdk.sampleapp.ShareAttributesResultBroadcastReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.test.app.YOTI_CALLBACK" />
                 <action android:name="com.test.app.BACKEND_CALLBACK" />

--- a/sample-app/src/main/AndroidManifest.xml
+++ b/sample-app/src/main/AndroidManifest.xml
@@ -12,7 +12,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
             android:launchMode="singleInstance"
             android:theme="@style/SampleAppTheme">
             <intent-filter>
@@ -22,7 +24,9 @@
             </intent-filter>
         </activity>
 
-        <receiver android:name=".ShareAttributesResultBroadcastReceiver" android:exported="false">
+        <receiver
+            android:name=".ShareAttributesResultBroadcastReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.test.app.YOTI_CALLBACK" />
                 <action android:name="com.test.app.BACKEND_CALLBACK" />

--- a/yoti-sdk/src/main/AndroidManifest.xml
+++ b/yoti-sdk/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.yoti.mobile.android.sdk">
 
+    <queries>
+        <package android:name="com.yoti.mobile.android.live" />
+        <package android:name="com.postofficeid.mobile.android.live" />
+    </queries>
+
     <application
         android:label="@string/app_name">
         <activity android:name=".ReceiverActivity"

--- a/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/kernelSDK/KernelSDKIntentService.java
+++ b/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/kernelSDK/KernelSDKIntentService.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.net.Uri;
+import android.os.Build;
 import android.os.ResultReceiver;
 import android.text.TextUtils;
 
@@ -150,8 +151,15 @@ public class KernelSDKIntentService extends IntentService {
             intent.setData(uri);
         }
 
+        int flags;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
+        } else {
+            flags = PendingIntent.FLAG_UPDATE_CURRENT;
+        }
         Intent wakeupIntent = new Intent(this, ReceiverActivity.class);
-        PendingIntent pendingIntent = PendingIntent.getActivity(this, 1, wakeupIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 1, wakeupIntent, flags);
+
 
         intent.putExtra(YOTI_PENDING_INTENT_EXTRA, pendingIntent);
 


### PR DESCRIPTION
Update pending intent flags to support Android 12 and above.

B&T
On Android 12 run the sample app and tap the button. 
Make sure you do not see the following exception:
```
Fatal Exception: java.lang.IllegalArgumentException: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
```