### PR TITLE
[YM-25986] Add configurable app packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.3.2] - 2022-03-28
+### Changed
+- Add configurable app packages (automation fix)
+
 ## [1.3.1] - 2022-02-22
 ### Changed
 - Update pending intent flags to support Android 12.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## [1.3.3] - 2022-04-04
+### Changed
+- Add configurable app packages (automation fix)
+
 ## [1.3.2] - 2022-03-30
 ### Fixed
 - Fix crash when returning from Digital IDs Apps.
-
-## [1.3.2] - 2022-03-28
-### Changed
-- Add configurable app packages (automation fix)
 
 ## [1.3.1] - 2022-02-22
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,9 +56,9 @@ easyIDScheme=easyid://
 pomId=yoti-button-sdk
 pomGroup=com.yoti.mobile.android.sdk
 pomPackaging=aar
-pomVersion=1.3.2
+pomVersion=1.3.3
 pomDescription=Button SDK that allows 3rd party to trigger Yoti as support app
-currentVersionCode=000012
+currentVersionCode=000013
 
 pomLicenseName=MIT
 pomLicenseUrl=https://github.com/getyoti/android-sdk-button/blob/master/LICENSE.md

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,9 +56,9 @@ easyIDScheme=easyid://
 pomId=yoti-button-sdk
 pomGroup=com.yoti.mobile.android.sdk
 pomPackaging=aar
-pomVersion=1.3.1
+pomVersion=1.3.2
 pomDescription=Button SDK that allows 3rd party to trigger Yoti as support app
-currentVersionCode=000011
+currentVersionCode=000012
 
 pomLicenseName=MIT
 pomLicenseUrl=https://github.com/getyoti/android-sdk-button/blob/master/LICENSE.md

--- a/yoti-sdk/build.gradle
+++ b/yoti-sdk/build.gradle
@@ -17,8 +17,13 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-        buildConfigField 'String', 'YOTI_APP_PACKAGE', "\"$yotiAppPackage\""
-        buildConfigField 'String', 'EASY_ID_APP_PACKAGE', "\"$easyIdAppPackage\""
+        def yotiAppPackageValue = "$yotiAppPackage"
+        def easyIdAppPackageValue = "$easyIdAppPackage"
+
+        manifestPlaceholders = [yotiAppPackage: yotiAppPackageValue, easyIdAppPackage: easyIdAppPackageValue]
+
+        buildConfigField 'String', 'YOTI_APP_PACKAGE', "\"${yotiAppPackageValue}\""
+        buildConfigField 'String', 'EASY_ID_APP_PACKAGE', "\"$easyIdAppPackageValue\""
         buildConfigField 'int', 'YOTI_APP_MIN_VERSION', yotiAppMinVersion
         buildConfigField 'String', 'YOTI_BACKEND_URL', "\"$yotiBackendUrl\""
         buildConfigField 'int', 'YOTI_BACKEND_PORT', "$yotiBackendPort"

--- a/yoti-sdk/src/main/AndroidManifest.xml
+++ b/yoti-sdk/src/main/AndroidManifest.xml
@@ -3,8 +3,8 @@
     package="com.yoti.mobile.android.sdk">
 
     <queries>
-        <package android:name="com.yoti.mobile.android.live" />
-        <package android:name="com.postofficeid.mobile.android.live" />
+        <package android:name="${yotiAppPackage}" />
+        <package android:name="${easyIdAppPackage}" />
     </queries>
 
     <application


### PR DESCRIPTION
Add configurable app packages. 
This fixes the issue we were experiencing running automation tests.
https://lampkicking.atlassian.net/browse/YM-25986

B&T
Run the sample app and make sure it transitions to the Yoti app.