### PR TITLE
[YM-26133] Fix return to SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## [1.3.2] - 2022-03-30
+### Fixed
+- Fix crash when returning from Digital IDs Apps.
 
 ## [1.3.1] - 2022-02-22
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,9 +56,9 @@ easyIDScheme=easyid://
 pomId=yoti-button-sdk
 pomGroup=com.yoti.mobile.android.sdk
 pomPackaging=aar
-pomVersion=1.3.1
+pomVersion=1.3.2
 pomDescription=Button SDK that allows 3rd party to trigger Yoti as support app
-currentVersionCode=000011
+currentVersionCode=000012
 
 pomLicenseName=MIT
 pomLicenseUrl=https://github.com/getyoti/android-sdk-button/blob/master/LICENSE.md

--- a/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/ReceiverActivity.java
+++ b/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/ReceiverActivity.java
@@ -12,7 +12,6 @@ public class ReceiverActivity extends AppCompatActivity {
 
         Intent intent = new Intent(getIntent().getAction());
         intent.setPackage(getIntent().getPackage());
-        intent.putExtras(getIntent().getExtras());
 
         sendBroadcast(intent);
 


### PR DESCRIPTION
## Purpose
Fix issue when return to SDK from Digital IDs

## External References (e.g. Jira / Zeplin / Confluence)
[YM-26133](https://lampkicking.atlassian.net/jira/software/c/projects/YM/issues/YM-26133)

## Approach
Remove use of pending intent extras.

## Scope of changes
ReceiverActivity intent management.

## Checklist
**Requirements**

Yoti App production version installed with phone attributes available to share (your Yoti personal account)

- [x] Dev testing passed 
1. Execute sample-app-3.
2. Any SDK theme is valid, tap on the Button and complete the attribute share in Yoti App.

EXP: we return to Yoti Button SDK and result is "Success" (green bar appears on top of the session data) 

- [x] QA testing passed: 
QA sign off provided https://lampkicking.atlassian.net/browse/YM-26133?focusedCommentId=215252



