### PR TITLE
[YM-26407] Restore callback behaviour and make it compatible with Android 12

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,10 +16,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle${{ hashFiles('gradle/wrapper/gradle-wrapper.properties')}}-
           ${{ runner.os }}-
-    - name: set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
 
     - name: Run tests with Gradle
       run: ./gradlew testDebug --no-daemon

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle${{ hashFiles('gradle/wrapper/gradle-wrapper.properties')}}-
           ${{ runner.os }}-
-    - name: set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
 
     - name: Run tests with Gradle
       run: ./gradlew testDebug --no-daemon

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@
 
 minSdkVersionVersion=21
 targetSdkVersion=31
-compileSdkVersion=28
+compileSdkVersion=31
 
 uiWidgetsVersion=1.9.0
 supportLibraryVersion=1.0.2
@@ -56,7 +56,7 @@ easyIDScheme=easyid://
 pomId=yoti-button-sdk
 pomGroup=com.yoti.mobile.android.sdk
 pomPackaging=aar
-pomVersion=1.3.3
+pomVersion=1.3.4
 pomName=Yoti Button SDK
 pomDescription=Button SDK that allows 3rd party to trigger Yoti as support app
 currentVersionCode=000013

--- a/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/ReceiverActivity.java
+++ b/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/ReceiverActivity.java
@@ -12,6 +12,7 @@ public class ReceiverActivity extends AppCompatActivity {
 
         Intent intent = new Intent(getIntent().getAction());
         intent.setPackage(getIntent().getPackage());
+        intent.putExtras(getIntent().getExtras());
 
         sendBroadcast(intent);
 

--- a/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/kernelSDK/KernelSDKIntentService.java
+++ b/yoti-sdk/src/main/java/com/yoti/mobile/android/sdk/kernelSDK/KernelSDKIntentService.java
@@ -152,8 +152,8 @@ public class KernelSDKIntentService extends IntentService {
         }
 
         int flags;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE;
         } else {
             flags = PendingIntent.FLAG_UPDATE_CURRENT;
         }


### PR DESCRIPTION
## Purpose
Fix callbacks and make them work for Android 12.

## External References (e.g. Jira / Zeplin / Confluence)
[YM-26407](https://lampkicking.atlassian.net/browse/YM-26407)

## Approach
Make pendingIntent explicitly mutable for Android 12, for other Android versions < 12 pendingIntent is mutable by default.  

## Scope of changes
PendingIntent creation & management.

## Checklist
**Requirements**

* For production environment, it is enough with the PR build and with your Yoti app installed in the device.
* If you want to run the B&T with the staging environment: clone this branch locally and check ticket [comment](https://lampkicking.atlassian.net/browse/YM-26407) for testing instruction.

- [x] Dev testing passed (production instructions)

1. Need your Yoti App production account.
2. Install sample-3 app, you can download the apk from here https://github.com/getyoti/android-sdk-button/actions/runs/2202751348
3. Any SDK theme is valid, tap on the Button and complete the attribute share in Yoti App (phone number share).

EXP: we return to Yoti Button SDK and result is "SUCCESS" (green bar appears on top of the session data) and there is a huge URL shown. 

- [x] QA testing passed



