### PR TITLE
[YM-26407] Fix publication script deploy task: point to JDK 11

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,10 +63,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle${{ hashFiles('gradle/wrapper/gradle-wrapper.properties')}}-
           ${{ runner.os }}-
-    - name: set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
 
     - name: Publish to maven
       env:


### PR DESCRIPTION
Continuation of https://github.com/getyoti/android-sdk-button/pull/28